### PR TITLE
Various fixes for buildsystem issues

### DIFF
--- a/LV-CLI Common Steps.vipb
+++ b/LV-CLI Common Steps.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="0.6" Created_Date="2017-05-16 13:34:33" Modified_Date="2017-08-07 15:56:09" Creator="Lee Harding" Comments="" ID="96901573333b89d88b9d59ba7f351102">
+<VI_Package_Builder_Settings Version="0.6" Created_Date="2017-05-16 13:34:33" Modified_Date="2017-09-11 16:12:44" Creator="Lee Harding" Comments="" ID="2ab23f0ce4d2ed9ffdaba4b8639720c3">
   <Library_General_Settings>
     <Package_File_Name>ni_lib_LV_CLI_Common_Steps</Package_File_Name>
-    <Library_Version>1.0.2.15</Library_Version>
+    <Library_Version>1.0.2.16</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>.</Library_Source_Folder>
     <Library_Output_Folder>exports</Library_Output_Folder>

--- a/steps/github_commenter.py
+++ b/steps/github_commenter.py
@@ -39,7 +39,13 @@ def _parse_options(args):
         "-i", "--info",
         dest="info",
         metavar="INFO",
-        help="Information about the org, repo, and pull request you are trying to use, e.g. 'LabVIEW-DCAF/IntegrationTesting/PR-13"
+        help="Information about the org, repo, and pull request you are trying to use, e.g. 'LabVIEW-DCAF/IntegrationTesting/PR-13'"
+    )
+    parser.add_option(
+        "-r", "--pic-repo",
+        dest="picRepo",
+        metavar="REPO",
+        help="The owner and repo to post to on github, e.g. 'theSloopJohnB/thesloopjohnb' for https://github.com/theSloopJohnB/thesloopjohnb"
     )
     
     debugGroup = optparse.OptionGroup(parser, "Debug")
@@ -100,7 +106,7 @@ def main(args):
         print(doctest.testmod())
         return
     else:
-    	post_pics_to_pr.post_pics_to_pr(options.token, options.picDir, options.info, options.pr)
+    	post_pics_to_pr.post_pics_to_pr(options.token, options.picDir, options.info, options.pr, options.picRepo)
 
     return 0
 

--- a/steps/labview.bat
+++ b/steps/labview.bat
@@ -11,6 +11,7 @@
 
 :VI2Check
 @if "%vi2:~-3%" == ".vi" GOTO :DIFF_VI
+@GOTO :END
 
 :DIFF_VI
     labview-cli --kill --lv-ver %lv_version% L:\lvDiff.vi -- "%vi1%" "%vi2%" "%working_dir%"

--- a/steps/post_pics_to_pr.py
+++ b/steps/post_pics_to_pr.py
@@ -18,12 +18,12 @@ def _read_picture(file_name):
         return base64.b64encode(text.read()).decode()
 
 
-def _post_file(file_data, folder, file_name, header):
+def _post_file(file_data, folder, file_name, header,picRepo):
     # put encoded data into json request
     new_file_data = json.dumps({"message": "commit message", "content":file_data})
 
     # post a picture to a repo
-    url = 'https://api.github.com/repos/theSloopJohnB/thesloopjohnb/contents/%s/%s' % (folder, file_name)
+    url = 'https://api.github.com/repos/%s/contents/%s/%s' % (folder, file_name)
     
     r=requests.put(url, data=new_file_data, headers=header)
     if (r.ok):
@@ -58,14 +58,14 @@ Notice something funny? Help fix me on [my GitHub repo.](https://github.com/LabV
         _moduleLogger.error('Bad response code: %s', r.status_code)
         _moduleLogger.error('Bad response text: %s', r.text)
 
-def post_pics_to_pr(token, localPicfileDirectory, pullRequestInfo, prNumber):
+def post_pics_to_pr(token, localPicfileDirectory, pullRequestInfo, prNumber, picRepo):
     header = _create_header(token)
     pics = [f for f in os.listdir(localPicfileDirectory) if f.endswith(".png")]
     folder = pullRequestInfo + '/' + datetime.datetime.now().strftime('%Y-%m-%d/%H:%M:%S')
     picUrls = []
     for pic in pics:
         picData = _read_picture(os.path.join(localPicfileDirectory, pic))
-        picUrl = _post_file(picData, folder, os.path.split(pic)[1], header)
+        picUrl = _post_file(picData, folder, os.path.split(pic)[1], header, picRepo)
         picUrls.append((pic, picUrl))
 
     if picUrls != []:

--- a/steps/post_pics_to_pr.py
+++ b/steps/post_pics_to_pr.py
@@ -68,4 +68,5 @@ def post_pics_to_pr(token, localPicfileDirectory, pullRequestInfo, prNumber):
         picUrl = _post_file(picData, folder, os.path.split(pic)[1], header)
         picUrls.append((pic, picUrl))
 
-    _post_comment_to_pr(picUrls, pullRequestInfo, prNumber, header) 
+    if picUrls != []:
+        _post_comment_to_pr(picUrls, pullRequestInfo, prNumber, header) 

--- a/steps/post_pics_to_pr.py
+++ b/steps/post_pics_to_pr.py
@@ -18,12 +18,12 @@ def _read_picture(file_name):
         return base64.b64encode(text.read()).decode()
 
 
-def _post_file(file_data, folder, file_name, header):
+def _post_file(file_data, folder, file_name, header,picRepo):
     # put encoded data into json request
     new_file_data = json.dumps({"message": "commit message", "content":file_data})
 
     # post a picture to a repo
-    url = 'https://api.github.com/repos/theSloopJohnB/thesloopjohnb/contents/%s/%s' % (folder, file_name)
+    url = 'https://api.github.com/repos/%s/contents/%s/%s' % (picRepo, folder, file_name)
     
     r=requests.put(url, data=new_file_data, headers=header)
     if (r.ok):
@@ -58,14 +58,14 @@ Notice something funny? Help fix me on [my GitHub repo.](https://github.com/LabV
         _moduleLogger.error('Bad response code: %s', r.status_code)
         _moduleLogger.error('Bad response text: %s', r.text)
 
-def post_pics_to_pr(token, localPicfileDirectory, pullRequestInfo, prNumber):
+def post_pics_to_pr(token, localPicfileDirectory, pullRequestInfo, prNumber, picRepo):
     header = _create_header(token)
     pics = [f for f in os.listdir(localPicfileDirectory) if f.endswith(".png")]
     folder = pullRequestInfo + '/' + datetime.datetime.now().strftime('%Y-%m-%d/%H:%M:%S')
     picUrls = []
     for pic in pics:
         picData = _read_picture(os.path.join(localPicfileDirectory, pic))
-        picUrl = _post_file(picData, folder, os.path.split(pic)[1], header)
+        picUrl = _post_file(picData, folder, os.path.split(pic)[1], header, picRepo)
         picUrls.append((pic, picUrl))
 
     if picUrls != []:

--- a/vars/dcafPipeline.groovy
+++ b/vars/dcafPipeline.groovy
@@ -38,13 +38,7 @@ def continueBuild
       // If this change is a pull request and the DIFFING_ENABLED variable is set on the jenkins master, diff vis.
       if (env.CHANGE_ID && env.DIFFING_ENABLED) {
         stage ('Diff VIs'){
-          echo 'Running LabVIEW diff build between origin/master and this commit' 
-          def diffDir = "${WORKSPACE}\\diff_dir"
-          bat "if exist ${diffDir} rd /s /q ${diffDir}"
-          bat "mkdir ${diffDir}"
-          bat "git difftool --no-prompt --extcmd=\"'L:\\labview.bat' \$LOCAL \$REMOTE diff_dir ${lvVersion}\" origin/master HEAD"
-          // Silencing echo so as to not print out the token.
-          bat "@python L:\\github_commenter.py --token=${GITHUB_DIFF_TOKEN} --pic-dir=${diffDir} --pull-req=${CHANGE_ID} --info=${JOB_NAME}"
+          lvDiff(lvVersion)
         }
       }
       stage ('Check Preconditions for Build'){

--- a/vars/dcafPipeline.groovy
+++ b/vars/dcafPipeline.groovy
@@ -24,7 +24,7 @@ switch(lvVersion){  //This is to abstract out the different Jenkinsfile conventi
 }
 
 def continueBuild
-  node(lvVersion){
+  node("proto"){
         echo 'Starting build...'
       stage ('Pre-Clean'){
         preClean()

--- a/vars/dcafPipeline.groovy
+++ b/vars/dcafPipeline.groovy
@@ -73,10 +73,11 @@ def continueBuild
             }
           }
         }
-
-        stage ('VIP_Deploy'){
-          timeout(time: 10, unit: 'MINUTES'){
-            vipPublish('DCAF Unstable')
+        if (env.BRANCH_NAME == 'master') { // Only deploy if on the master branch.
+          stage ('VIP_Deploy'){
+            timeout(time: 10, unit: 'MINUTES'){
+              vipPublish('DCAF Unstable')
+            }
           }
         }
       //stage ('SCM commit'){

--- a/vars/dcafPipeline.groovy
+++ b/vars/dcafPipeline.groovy
@@ -35,8 +35,8 @@ def continueBuild
           checkout scm
         }
       }
-      // If this change is a pull request and the DIFFING_ENABLED variable is set on the jenkins master, diff vis.
-      if (env.CHANGE_ID && env.DIFFING_ENABLED) {
+      // If this change is a pull request and the DIFFING_PIC_REPO variable is set on the jenkins master, diff vis.
+      if (env.CHANGE_ID && env.DIFFING_PIC_REPO) {
         stage ('Diff VIs'){
           lvDiff(lvVersion)
         }

--- a/vars/lvDiff.groovy
+++ b/vars/lvDiff.groovy
@@ -1,0 +1,9 @@
+def call(lvVersion) {
+	    echo 'Running LabVIEW diff build between origin/master and this commit'
+        def diffDir = "${WORKSPACE}\\diff_dir"
+        bat "if exist ${diffDir} rd /s /q ${diffDir}"
+        bat "mkdir ${diffDir}"
+        bat "git difftool --no-prompt --extcmd=\"'L:\\labview.bat' \$LOCAL \$REMOTE diff_dir ${lvVersion}\" origin/master HEAD"
+        // Silencing echo so as to not print out the token.
+        bat "@python L:\\github_commenter.py --token=${GITHUB_DIFF_TOKEN} --pic-dir=${diffDir} --pull-req=${CHANGE_ID} --info=${JOB_NAME}"
+}

--- a/vars/lvDiff.groovy
+++ b/vars/lvDiff.groovy
@@ -5,5 +5,5 @@ def call(lvVersion) {
         bat "mkdir ${diffDir}"
         bat "git difftool --no-prompt --extcmd=\"'L:\\labview.bat' \$LOCAL \$REMOTE diff_dir ${lvVersion}\" origin/master HEAD"
         // Silencing echo so as to not print out the token.
-        bat "@python L:\\github_commenter.py --token=${GITHUB_DIFF_TOKEN} --pic-dir=${diffDir} --pull-req=${CHANGE_ID} --info=${JOB_NAME}"
+        bat "@python L:\\github_commenter.py --token=${GITHUB_DIFF_TOKEN} --pic-dir=${diffDir} --pull-req=${CHANGE_ID} --info=${JOB_NAME} --pic-repo=${DIFFING_PIC_REPO}"
 }


### PR DESCRIPTION
fixes #28 by not deploying VIP files to unstable repo

fixes #25, lets you configure picture repo for diffs.

fixes bug where diff could run on non VIs that were added

fixes #29, to stop commenting if there were no VIs in a changelist.

fixes #26 by moving diff code into its own file